### PR TITLE
📦 Bump npm:css-what from 4.0.0 to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^4.0.0",
+        "css-what": "5.0.1",
         "domhandler": "^4.0.0",
         "domutils": "^2.4.3",
         "nth-check": "^2.0.0"


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2021-33587 | High  | The css-what package 4.0.0 through 5.0.0 for Node.js does not ensure that<br>attribute parsing has Linear Time Complexity relative to the size of the input. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
